### PR TITLE
feat: #3 カレンダー表にスタンプ反映

### DIFF
--- a/lib/event.dart
+++ b/lib/event.dart
@@ -2,7 +2,8 @@ class Event {
   final String title;
   final String? description;
   final DateTime dateTime;
+  final String imagePath;
 
   Event(
-      {required this.title, this.description, required this.dateTime});
+      {required this.title, this.description, required this.dateTime, required this.imagePath});
 }

--- a/lib/table_calendar_event_provider.dart
+++ b/lib/table_calendar_event_provider.dart
@@ -6,11 +6,16 @@ part 'table_calendar_event_provider.g.dart';
 @riverpod
 class TableCalendarEventController extends _$TableCalendarEventController {
   final List<Event> sampleEvents = [
-    Event(title: 'firstEvent', dateTime: DateTime.utc(2024, 2, 15)),
+    Event(
+      title: 'firstEvent',
+      dateTime: DateTime.utc(2024, 2, 15),
+      imagePath: 'assets/images/stamp_yasumi.png',
+    ),
     Event(
       title: 'secondEvent',
       description: 'description',
       dateTime: DateTime.utc(2024, 2, 15),
+      imagePath: 'assets/images/stamp_shuukinn.png',
     ),
   ];
 
@@ -24,11 +29,13 @@ class TableCalendarEventController extends _$TableCalendarEventController {
     required DateTime dateTime,
     required String title,
     String? description,
+    required String imagePath,
   }) {
     var newData = Event(
       title: title,
       description: description,
       dateTime: dateTime,
+      imagePath: imagePath,
     );
     state.add(newData);
   }


### PR DESCRIPTION
close #9

## 変更点
スタンプ画像をデータとして、一時保存しカレンダーへ表示できるように
実装。
①event.dartモデルへ画像のパスを保持。
`final String imagePath;`と `required this.imagePath,`

②main.dartへスタンプダイアログを変更。
imageをstampImagesと定義。
 await showDialog以降を変更。

③main.dartのtablecalenderへスタンプ表示を追加。
eventLoader:(date) を編集。

[![Image from Gyazo](https://i.gyazo.com/89869863771105f6862882f51310b738.gif)](https://gyazo.com/89869863771105f6862882f51310b738)